### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
 
+permissions:
+  contents: write
+
 jobs:
   build-pack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Grant the workflow GITHUB_TOKEN 'contents: write' so softprops/action-gh-release can create releases.