### PR TITLE
Ensure PAK output uses tilde prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,6 @@ jobs:
       - name: Build localization PAKs
         run: node ./dist/cli.js pack artifacts
 
-      - name: Prefix PAK filenames with tilde
-        shell: bash
-        run: |
-          shopt -s nullglob
-          for file in artifacts/*.pak; do
-            base="$(basename "$file")"
-            case "$base" in
-              ~*) ;;
-              *) mv "$file" "artifacts/~$base" ;;
-            esac
-          done
-
       - name: Generate checksums
         shell: bash
         run: |

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -80,7 +80,8 @@ export async function buildPak(options: PackOptions): Promise<void> {
 
     const finalDir = path.resolve(outputDir);
     await mkdir(finalDir, { recursive: true });
-    const finalPakPath = path.join(finalDir, `${pakBase}.pak`);
+    const finalBaseName = pakBase.startsWith('~') ? pakBase : `~${pakBase}`;
+    const finalPakPath = path.join(finalDir, `${finalBaseName}.pak`);
     await rename(pakTempPath, finalPakPath);
 
     console.log(`[${language ?? 'default'}] Locres written to ${locresPath}`);


### PR DESCRIPTION
Tag the generated PAK filenames directly in the pack command so CI no longer needs to rename them.