### PR TITLE
Zip release artifacts with sanitized names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,27 @@ jobs:
       - name: Build localization PAKs
         run: node ./dist/cli.js pack artifacts
 
+      - name: Zip PAKs for release
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for file in artifacts/~*.pak; do
+            base="$(basename "$file")"
+            zip_basename="${base#~}"
+            zip_basename="${zip_basename%.pak}"
+            zip_path="artifacts/${zip_basename}.zip"
+            zip -j "$zip_path" "$file"
+            rm "$file"
+          done
+
       - name: Generate checksums
         shell: bash
         run: |
           set -euo pipefail
           cd artifacts
           shopt -s nullglob
-          files=(~*.pak)
+          files=(~*.pak.zip)
           if [ ${#files[@]} -eq 0 ]; then
             echo "No PAK files found in artifacts/" >&2
             exit 1
@@ -75,7 +89,7 @@ jobs:
           name: Localization Build ${{ steps.release.outputs.tag }}
           target_commitish: ${{ github.sha }}
           files: |
-            artifacts/~*.pak
+            artifacts/~*.pak.zip
             artifacts/checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 ## Tiếng Việt
 
 ### Cài đặt nhanh
-1. Tải gói `~VI_PATCH.pak` mới nhất từ trang [Releases](https://github.com/yakiro-nvg/wojd_trans/releases/latest).
-2. Sao chép vào thư mục trò chơi (ví dụ):
+1. Tải gói `VI_PATCH.zip` mới nhất từ trang [Releases](https://github.com/yakiro-nvg/wojd_trans/releases/latest).
+2. Giải nén để thu được `~VI_PATCH.pak`.
+3. Sao chép `~VI_PATCH.pak` vào thư mục trò chơi (ví dụ):
    ```
    C:\Program Files\ZXSJclient\ZXSJ\Game\ZhuxianClient\Content\Paks
    ```
-3. Xóa các bản Việt hóa cũ (nếu có) trước khi chép gói mới.
+4. Xóa các bản Việt hóa cũ (nếu có) trước khi chép gói mới.
 
 ### Thông tin thêm
 - [Phương pháp dịch thuật](docs/methodology.md)
@@ -19,12 +20,13 @@
 ## English
 
 ### Quick Install
-1. Download the latest `~EN_PATCH.pak` from the [Releases](https://github.com/yakiro-nvg/wojd_trans/releases/latest) page.
-2. Copy it into your game folder, e.g.:
+1. Download the latest `EN_PATCH.zip` from the [Releases](https://github.com/yakiro-nvg/wojd_trans/releases/latest) page.
+2. Extract it to obtain `~EN_PATCH.pak`.
+3. Copy `~EN_PATCH.pak` into your game folder, e.g.:
    ```
    C:\Program Files\ZXSJclient\ZXSJ\Game\ZhuxianClient\Content\Paks
    ```
-3. Remove any older translation PAK before dropping in the new one.
+4. Remove any older translation PAK before dropping in the new one.
 
 ### More Info
 - [Localization pipeline](docs/methodology.md)


### PR DESCRIPTION
Create ZIP archives without the leading tilde so GitHub preserves the attachment name while keeping the internal ~PAK. Update README install steps accordingly.